### PR TITLE
Error out if no mail rule found

### DIFF
--- a/lib/emailjs.js
+++ b/lib/emailjs.js
@@ -215,7 +215,7 @@ exportable = (function () {
     }
     if (eventName) {
       if (instance.eventNames().includes(eventName)) {
-        instance.emit(eventName, arguments);
+        instance.emit(eventName, content, options, cb);
       } else {
         return handleExcp(cb, `No rule found for event: ${eventName}`);
       }

--- a/lib/emailjs.js
+++ b/lib/emailjs.js
@@ -50,7 +50,7 @@ exportable = (function () {
     .then(initializeRetryListener)
     .then(function () {    
       initialized = true;
-      log('Ready from modified branch');
+      log('Ready');
       instance.emit('ready');
       // Success
       if (cb) {

--- a/lib/emailjs.js
+++ b/lib/emailjs.js
@@ -208,6 +208,20 @@ exportable = (function () {
       setTimeout(retryErrorMails, retryInterval);  
     }
   }
+  
+  function emitWrapper () {
+    const eventName = arguments && arguments[0],
+      cb = arguments.length > 3 ? arguments[3] : null;
+    if (eventName) {
+      if (instance.eventNames().includes(eventName)) {
+        instance.emit(eventName, arguments);
+      } else {
+        return handleExcp(cb, 'No rule found for event: ' + eventName);
+      }
+    } else {
+      return handleExcp(cb, 'No event specified');
+    }
+  }
 
   function handleIncomingEvent () {
     log('Processing event: '+arguments[0].eventname);
@@ -454,7 +468,7 @@ exportable = (function () {
   emailJS.on = instance.on.bind(instance);
   emailJS.connect = init;
   emailJS.send = send;
-  emailJS.fire = instance.emit.bind(instance);
+  emailJS.fire = emitWrapper;
   return emailJS;    
 })();
 

--- a/lib/emailjs.js
+++ b/lib/emailjs.js
@@ -50,7 +50,7 @@ exportable = (function () {
     .then(initializeRetryListener)
     .then(function () {    
       initialized = true;
-      log('Ready');
+      log('Ready from modified branch');
       instance.emit('ready');
       // Success
       if (cb) {

--- a/lib/emailjs.js
+++ b/lib/emailjs.js
@@ -209,14 +209,15 @@ exportable = (function () {
     }
   }
   
-  function emitWrapper () {
-    const eventName = arguments && arguments[0],
-      cb = arguments.length > 3 ? arguments[3] : null;
+  function emitWrapper (eventName, content, options, cb) {
+    if (!cb){
+      cb = null;
+    }
     if (eventName) {
       if (instance.eventNames().includes(eventName)) {
         instance.emit(eventName, arguments);
       } else {
-        return handleExcp(cb, 'No rule found for event: ' + eventName);
+        return handleExcp(cb, `No rule found for event: ${eventName}`);
       }
     } else {
       return handleExcp(cb, 'No event specified');


### PR DESCRIPTION
### Summary
- No mail rule in DB means there is no corresponding listener attached 
- Passing such an event in emailjs.fire causes execution to get stuck
- PR enhances this and errors out in case such a scenario occurs 

### JIRA Ticket 
-https://jira.nutanix.com/browse/SAAS-3885

### Steps to Test 
- Install emailjs from this branch 
- Remove Mail rule and execute job which requires the mail rule to be present. Emailjs should throw an error saying no mail rule found. 
- Put back the mail rule in the db, mail should be sent without hitches.