### PR TITLE
Waterline and sails-postgresql version upgrade

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -9,13 +9,14 @@ module.exports = {
       rulestable: 'mail_rules'
     }
   },
-  connections: {
+  datastores: {
     enabledProvider: 'postgres',
     providers: {
       postgres: {
         adapter: 'sails-postgresql',
+        schemaName: 'sloop_one',
         url: 'postgres://localhost/test',
-        ssl: true,
+        ssl: { rejectUnauthorized: false },
         multipleStatements: true,
         wlNext: {
           caseSensitive: true

--- a/lib/emailjs.js
+++ b/lib/emailjs.js
@@ -137,8 +137,8 @@ exportable = (function () {
     if (config.connections.enabledProvider !== 'postgres') {
       return deferred.resolve();
     }
-    orm.config.connections.myPostgres = Object.assign({}, 
-      defConfig.connections.providers.postgres, 
+    orm.config.datastores.myPostgres = Object.assign({}, 
+      defConfig.datastores.providers.postgres, 
       config.connections.providers.postgres);
     orm.schemaConfig.settings = Object.assign({}, 
       defConfig.defaults.schema, config.defaults.schema);
@@ -149,7 +149,7 @@ exportable = (function () {
         deferred.reject(err);
       } else {
         db.models = models.collections;
-        db.connections = models.connections;
+        db.connections = models.datastores;
         log('Initialized postgres models');
         deferred.resolve();	
       }

--- a/lib/emailjs.js
+++ b/lib/emailjs.js
@@ -308,8 +308,9 @@ exportable = (function () {
     options = options || {};
 
     var template = templates[options.template];
+    var isHTML = options.isHTML;
 
-    if (!template) { 
+    if (!template && !isHTML) { 
       return handleExcp(cb, 'Template not found: '+options.template);
     }
     if (!options.to || !options.subject) {
@@ -318,7 +319,7 @@ exportable = (function () {
     }
 
     options.from = options.from || defaultFrom;
-    renderMail(template, content)
+    renderMail(template, content, options)
     .then(function (results) {
       options.html = results.html;
       options.text = results.text;
@@ -375,9 +376,13 @@ exportable = (function () {
     return deferred.promise;
   }
 
-  function renderMail (template, content) {
+  function renderMail (template, content, options) {
     var deferred = Q.defer();
-
+    if (options.isHTML && content) {
+      console.log('---------- Allowed sending custom email --------------');
+      deferred.resolve(content);
+      return deferred.promise;
+    }
     if (template) {
       template.render(content, function (err, results) {
         if (err) {

--- a/lib/orm/index.js
+++ b/lib/orm/index.js
@@ -8,7 +8,7 @@ var config = {
     'sails-postgresql': postgresAdapter
   },
 
-  connections: {
+  datastores: {
     myPostgres: { 
     }
   },
@@ -42,7 +42,7 @@ function initialize () {
       case 'mail_rules': model.tableName = schemaConfig.settings.rulestable; break;
     }
     model = Waterline.Collection.extend(model);
-    orm.loadCollection(model);
+    orm.registerModel(model);
   });
 }
 

--- a/lib/orm/mail_archive.js
+++ b/lib/orm/mail_archive.js
@@ -18,12 +18,12 @@ var Archive = {
     subject: {type: 'string', columnName: 'subject'},
     from: {type: 'string', columnName: 'from'},
     to: {type: 'string', columnName: 'to'},
-    cc: {type: 'string', columnName: 'cc'},
-    bcc: {type: 'string', columnName: 'bcc'},
+    cc: {type: 'string', columnName: 'cc', allowNull: true},
+    bcc: {type: 'string', columnName: 'bcc', allowNull: true},
     html: {type: 'string', columnName: 'html'},
-    text: {type: 'string', columnName: 'text'},
+    text: {type: 'string', columnName: 'text', allowNull: true},
     attachments: {type: 'json', columnName: 'attachments'},
-    error: {type: 'string', columnName: 'error'},
+    error: {type: 'string', columnName: 'error', allowNull: true},
     attempts: {type: 'number', columnName: 'attempts'}
   }
 };

--- a/lib/orm/mail_archive.js
+++ b/lib/orm/mail_archive.js
@@ -1,18 +1,17 @@
 /* jshint node:true */
 
 var Archive = {
-  connection: 'myPostgres',
+  datastore: 'myPostgres',
   tableName: 'mail_archive',
   identity: 'MailArchive',
   meta: {
     schemaName: 'public'
   },
-  autoPK: false,
-  autoCreatedAt: true,
-  autoUpdatedAt: true,
+  primaryKey: 'eid',
   attributes: {
-    eid: {type: 'integer', columnName: 'eid', 
-      primaryKey: true, autoIncrement: true},
+    createdAt: { type: 'string', autoCreatedAt: true, },
+    updatedAt: { type: 'string', autoUpdatedAt: true, },
+    eid: {type: 'number', columnName: 'eid', autoMigrations: {autoIncrement: true}},
     eventname: {type: 'string', columnName: 'eventname'},
     template: {type: 'string', columnName: 'template'},
     content: {type: 'json', columnName: 'content'},
@@ -25,7 +24,7 @@ var Archive = {
     text: {type: 'string', columnName: 'text'},
     attachments: {type: 'json', columnName: 'attachments'},
     error: {type: 'string', columnName: 'error'},
-    attempts: {type: 'integer', columnName: 'attempts'}
+    attempts: {type: 'number', columnName: 'attempts'}
   }
 };
 

--- a/lib/orm/mail_outbox.js
+++ b/lib/orm/mail_outbox.js
@@ -1,18 +1,17 @@
 /* jshint node:true */
 
 var Outbox = {
-  connection: 'myPostgres',
+  datastore: 'myPostgres',
   tableName: 'mail_outbox',
   identity: 'MailOutbox',
   meta: {
     schemaName: 'public'
   },
-  autoPK: false,
-  autoCreatedAt: true,
-  autoUpdatedAt: true,
+  primaryKey: 'eid',
   attributes: {
-    eid: {type: 'integer', columnName: 'eid', 
-      primaryKey: true, autoIncrement: true},
+    createdAt: { type: 'string', autoCreatedAt: true, },
+    updatedAt: { type: 'string', autoUpdatedAt: true, },
+    eid: {type: 'number', columnName: 'eid', autoMigrations: {autoIncrement: true}},
     eventname: {type: 'string', columnName: 'eventname'},
     template: {type: 'string', columnName: 'template'},
     content: {type: 'json', columnName: 'content'},
@@ -25,7 +24,7 @@ var Outbox = {
     text: {type: 'string', columnName: 'text'},
     attachments: {type: 'json', columnName: 'attachments'},
     error: {type: 'string', columnName: 'error'},
-    attempts: {type: 'integer', columnName: 'attempts'}
+    attempts: {type: 'number', columnName: 'attempts'}
   }
 };
 

--- a/lib/orm/mail_outbox.js
+++ b/lib/orm/mail_outbox.js
@@ -18,12 +18,12 @@ var Outbox = {
     subject: {type: 'string', columnName: 'subject'},
     from: {type: 'string', columnName: 'from'},
     to: {type: 'string', columnName: 'to'},
-    cc: {type: 'string', columnName: 'cc'},
-    bcc: {type: 'string', columnName: 'bcc'},
+    cc: {type: 'string', columnName: 'cc', allowNull: true},
+    bcc: {type: 'string', columnName: 'bcc', allowNull: true},
     html: {type: 'string', columnName: 'html'},
-    text: {type: 'string', columnName: 'text'},
+    text: {type: 'string', columnName: 'text', allowNull: true},
     attachments: {type: 'json', columnName: 'attachments'},
-    error: {type: 'string', columnName: 'error'},
+    error: {type: 'string', columnName: 'error', allowNull: true},
     attempts: {type: 'number', columnName: 'attempts'}
   }
 };

--- a/lib/orm/mail_rules.js
+++ b/lib/orm/mail_rules.js
@@ -1,25 +1,25 @@
 /* jshint node:true */
 
 var Rules = {
-  connection: 'myPostgres',
+  datastore: 'myPostgres',
   tableName: 'mail_rules',
   identity: 'MailRules',
   meta: {
     schemaName: 'public'
   },
-  autoPK: false,
-  autoCreatedAt: true,
-  autoUpdatedAt: true,
+  primaryKey: 'eventname',
   attributes: {
-    ruleid: {type: 'int', columnName: 'ruleid'},
-    eventname: {type: 'string', columnName: 'eventname'},
+    createdAt: { type: 'string', autoCreatedAt: true },
+    updatedAt: { type: 'string', autoUpdatedAt: true, },
+    ruleid: {type: 'string', columnName: 'ruleid', allowNull: true },
+    eventname: {type: 'string', columnName: 'eventname', required: true},
     enabled: {type: 'boolean', columnName: 'enabled'},
     template: {type: 'string', columnName: 'template'},
-    from: {type: 'string', columnName: 'from'},
-    to: {type: 'string', columnName: 'to'},
-    cc: {type: 'string', columnName: 'cc'},
-    bcc: {type: 'string', columnName: 'bcc'},
-    subject: {type: 'string', columnName: 'subject'}
+    from: {type: 'string', columnName: 'from', allowNull: true},
+    to: {type: 'string', columnName: 'to', allowNull: true},
+    cc: {type: 'string', columnName: 'cc', allowNull: true},
+    bcc: {type: 'string', columnName: 'bcc', allowNull: true},
+    subject: {type: 'string', columnName: 'subject', allowNull: true}
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "handlebars": "3.0.0",
     "q": "1.4.1",
     "lodash": "2.4.1",
-    "sails-postgresql": "0.11.4",
-    "waterline": "0.12.2"
+    "sails-postgresql": "2.0.0",
+    "waterline": "0.13.6"
   },
   "devDependencies": {
     "chai": "3.5.0",


### PR DESCRIPTION
### Summary
- Upgrading sloop to node v14.17.5 was making it incompatible with emailJS, due to compatibility issues with `waterline` and `sails-postgresql` 
- Upgraded waterline to `0.13.6` and sails-postgresql to `2.0.0` and changed nomenclature as required by the upgrades

### Steps to Test
- Install emails from this branch and use with node v14.17.5 (or lower)