### PR TITLE
Loading multiple template directory

### DIFF
--- a/lib/emailjs.js
+++ b/lib/emailjs.js
@@ -20,6 +20,7 @@ exportable = (function () {
     config = null,
     transport = null,
     templates = null,
+    loadedTemplateDirs = [],
     ruleSettings = [],
     defaultFrom = null,
     retryInterval = null,
@@ -35,12 +36,27 @@ exportable = (function () {
   instance = new email();
 
   function init (_templatesDir, _config, _rules, cb) {
-    if (initialized) {
-      return handleExcp(cb, new Error('Already initialized'));
-    }
     templatesDir = _templatesDir;
     config = _config;
     rules = _rules;
+
+    if (initialized) {
+      if (loadedTemplateDirs.includes(templatesDir)) {
+        return handleExcp(cb, new Error('Already initialized'));
+      } else {
+        return Q.fcall(validateInitialization)
+          .then(loadTemplates)
+          .then(function () {    
+            if (cb) {
+              cb(null, {});
+            }
+          })
+          .catch(function (err) {
+            handleExcp(cb, err);
+          });
+      }
+
+    }
 
     Q.fcall(validateInitialization)
     .then(loadTemplates)
@@ -107,7 +123,7 @@ exportable = (function () {
 
   function loadTemplates () {
     var deferred = Q.defer();
-    templates = {};
+    templates = templates || {};
 
     fs.readdir(templatesDir, function (err, dirs) {
       if (err) {
@@ -125,7 +141,7 @@ exportable = (function () {
             logWarn('Ignoring: '+dirPath);
           }  
         });
-   
+        loadedTemplateDirs.push(templatesDir);
         deferred.resolve();
       }
     });


### PR DESCRIPTION
### Summary
 - Creating a new API to trigger cron-job on billing-server required us to load email templates from two different directories.
 - Created a new array that will contain the list of directories from where the templates have been loaded. If some new path comes to load templates now those templates will be loaded successfully to memory.


### Steps to test
 - Install emailjs from this PR and hit the Cronjob API on billing-server.
 - Verify by running any job which sends an audit email and check the email is coming successfully.